### PR TITLE
MAINT: store/load `state_dict` of model/optimizer into/from files

### DIFF
--- a/lr_finder.py
+++ b/lr_finder.py
@@ -47,15 +47,15 @@ class LRFinder(object):
             import tempfile
             cache_dir = tempfile.gettempdir()
         else:
-            if os.path.isdir(cache_dir):
+            if not os.path.isdir(cache_dir):
                 raise ValueError('Given `cache_dir` is not a valid directory.')
 
         self.fn_model_state = os.path.join(cache_dir, 'model_state.pt')
         self.fn_optimizer_state = os.path.join(cache_dir, 'optimizer_state.pt')
 
-        self.model_state = torch.save(model.state_dict(), self.fn_model_state)
         self.model_device = next(self.model.parameters()).device
-        self.optimizer_state = torch.save(optimizer.state_dict(), self.fn_optimizer_state)
+        torch.save(model.state_dict(), self.fn_model_state)
+        torch.save(optimizer.state_dict(), self.fn_optimizer_state)
 
         # If device is None, use the same as the model
         if device:
@@ -66,16 +66,14 @@ class LRFinder(object):
     def reset(self):
         """Restores the model and optimizer to their initial states."""
         if os.path.exists(self.fn_model_state) and os.path.exists(self.fn_optimizer_state):
-        self.model.load_state_dict(
-            torch.load(self.fn_model_state, map_location=lambda storage, location: storage),
-            self.model_state
-        )
-        self.optimizer.load_state_dict(
-            torch.load(self.fn_optimizer_state, map_location=lambda storage, location: storage),
-            self.optimizer_state
-        )
-        os.remove(self.fn_model_state)
-        os.remove(self.fn_optimizer_state)
+            self.model.load_state_dict(
+                torch.load(self.fn_model_state, map_location=lambda storage, location: storage)
+            )
+            self.optimizer.load_state_dict(
+                torch.load(self.fn_optimizer_state, map_location=lambda storage, location: storage)
+            )
+            os.remove(self.fn_model_state)
+            os.remove(self.fn_optimizer_state)
 
     def range_test(
         self,

--- a/lr_finder.py
+++ b/lr_finder.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, with_statement, division
+import copy
 import os
 import torch
 from tqdm.autonotebook import tqdm
@@ -23,7 +24,12 @@ class LRFinder(object):
             optional ordinal for the device type (e.g. "cuda:X", where is the ordinal).
             Alternatively, can be an object representing the device on which the
             computation will take place. Default: None, uses the same device as `model`.
-        cache_dir (string): path for storing temporary files.
+        memory_cache (boolean): if this flag is set to True, `state_dict` of model and
+            optimizer will be cached in memory. Otherwise, they will be saved to files
+            under the `cache_dir`.
+        cache_dir (string): path for storing temporary files. If no path is specified,
+            system-wide temporary directory is used.
+            Notice that this parameter will be ignored if `memory_cache` is True.
 
     Example:
         >>> lr_finder = LRFinder(net, optimizer, criterion, device="cuda")
@@ -34,28 +40,21 @@ class LRFinder(object):
 
     """
 
-    def __init__(self, model, optimizer, criterion, device=None, cache_dir=None):
+    def __init__(self, model, optimizer, criterion, device=None, memory_cache=True, cache_dir=None):
         self.model = model
         self.optimizer = optimizer
         self.criterion = criterion
         self.history = {"lr": [], "loss": []}
         self.best_loss = None
+        self.memory_cache = memory_cache
+        self.cache_dir = cache_dir
 
         # Save the original state of the model and optimizer so they can be restored if
         # needed
-        if cache_dir is None:
-            import tempfile
-            cache_dir = tempfile.gettempdir()
-        else:
-            if not os.path.isdir(cache_dir):
-                raise ValueError('Given `cache_dir` is not a valid directory.')
-
-        self.fn_model_state = os.path.join(cache_dir, 'model_state.pt')
-        self.fn_optimizer_state = os.path.join(cache_dir, 'optimizer_state.pt')
-
         self.model_device = next(self.model.parameters()).device
-        torch.save(model.state_dict(), self.fn_model_state)
-        torch.save(optimizer.state_dict(), self.fn_optimizer_state)
+        self.state_cacher = StateCacher(memory_cache, cache_dir=cache_dir)
+        self.state_cacher.store('model', self.model.state_dict())
+        self.state_cacher.store('optimizer', self.optimizer.state_dict())
 
         # If device is None, use the same as the model
         if device:
@@ -65,15 +64,9 @@ class LRFinder(object):
 
     def reset(self):
         """Restores the model and optimizer to their initial states."""
-        if os.path.exists(self.fn_model_state) and os.path.exists(self.fn_optimizer_state):
-            self.model.load_state_dict(
-                torch.load(self.fn_model_state, map_location=lambda storage, location: storage)
-            )
-            self.optimizer.load_state_dict(
-                torch.load(self.fn_optimizer_state, map_location=lambda storage, location: storage)
-            )
-            os.remove(self.fn_model_state)
-            os.remove(self.fn_optimizer_state)
+        self.model.load_state_dict(self.state_cacher.retrieve('model'))
+        self.optimizer.load_state_dict(self.state_cacher.retrieve('optimizer'))
+        self.model.to(self.model_device)
 
     def range_test(
         self,
@@ -282,3 +275,40 @@ class ExponentialLR(_LRScheduler):
         curr_iter = self.last_epoch + 1
         r = curr_iter / self.num_iter
         return [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]
+
+
+class StateCacher(object):
+    def __init__(self, in_memory, cache_dir=None):
+        self.in_memory = in_memory
+        self.cache_dir = cache_dir
+
+        if self.cache_dir is None:
+            import tempfile
+            self.cache_dir = tempfile.gettempdir()
+        else:
+            if not os.path.isdir(self.cache_dir):
+                raise ValueError('Given `cache_dir` is not a valid directory.')
+
+        self.cached = {}
+
+    def store(self, key, state_dict):
+        if self.in_memory:
+            self.cached.update({key: copy.deepcopy(state_dict)})
+        else:
+            fn = os.path.join(self.cache_dir, 'state_{}.pt'.format(key))
+            self.cached.update({key: fn})
+            torch.save(state_dict, fn)
+
+    def retrieve(self, key):
+        if key not in self.cached:
+            raise KeyError('Target {} was not cached.'.format(key))
+
+        if self.in_memory:
+            return self.cached.pop(key)
+        else:
+            fn = self.cached.pop(key)
+            if not os.path.exists(fn):
+                raise RuntimeError('Failed to load state in {}. File does not exist anymore.'.format(fn))
+            state_dict = torch.load(fn, map_location=lambda storage, location: storage)
+            os.remove(fn)
+            return state_dict


### PR DESCRIPTION
`state_dict` is a mutable object (literally, it a `dict`), so that
it can be changed in runtime.

In the original version, we just hold a reference of `state_dict`,
not a copied instance. So that it won't work correctly if we want
to reset the state after running `LRFinder.range_test()`.

In order to keep the original state of model and optimizer, we have
to:
  1. make a deep copy of `state_dict`
  2. save `state_dict` into file, then load it back later

We choose the second method. Although it take a little more time on
reading and writing file, it avoids consuming extra memory. So that
it won't lead to an out-of-memory issue.