### PR TITLE
Remove file of cached `state_dict` only when `StateCacher` is going to be destroyed

### DIFF
--- a/lr_finder.py
+++ b/lr_finder.py
@@ -47,15 +47,15 @@ class LRFinder(object):
             import tempfile
             cache_dir = tempfile.gettempdir()
         else:
-            if os.path.isdir(cache_dir):
+            if not os.path.isdir(cache_dir):
                 raise ValueError('Given `cache_dir` is not a valid directory.')
 
         self.fn_model_state = os.path.join(cache_dir, 'model_state.pt')
         self.fn_optimizer_state = os.path.join(cache_dir, 'optimizer_state.pt')
 
-        self.model_state = torch.save(model.state_dict(), self.fn_model_state)
         self.model_device = next(self.model.parameters()).device
-        self.optimizer_state = torch.save(optimizer.state_dict(), self.fn_optimizer_state)
+        torch.save(model.state_dict(), self.fn_model_state)
+        torch.save(optimizer.state_dict(), self.fn_optimizer_state)
 
         # If device is None, use the same as the model
         if device:
@@ -66,16 +66,14 @@ class LRFinder(object):
     def reset(self):
         """Restores the model and optimizer to their initial states."""
         if os.path.exists(self.fn_model_state) and os.path.exists(self.fn_optimizer_state):
-        self.model.load_state_dict(
-            torch.load(self.fn_model_state, map_location=lambda storage, location: storage),
-            self.model_state
-        )
-        self.optimizer.load_state_dict(
-            torch.load(self.fn_optimizer_state, map_location=lambda storage, location: storage),
-            self.optimizer_state
-        )
-        os.remove(self.fn_model_state)
-        os.remove(self.fn_optimizer_state)
+            self.model.load_state_dict(
+                torch.load(self.fn_model_state, map_location=lambda storage, location: storage)
+            )
+            self.optimizer.load_state_dict(
+                torch.load(self.fn_optimizer_state, map_location=lambda storage, location: storage)
+            )
+            os.remove(self.fn_model_state)
+            os.remove(self.fn_optimizer_state)
 
     def range_test(
         self,

--- a/lr_finder.py
+++ b/lr_finder.py
@@ -295,7 +295,7 @@ class StateCacher(object):
         if self.in_memory:
             self.cached.update({key: copy.deepcopy(state_dict)})
         else:
-            fn = os.path.join(self.cache_dir, 'state_{}.pt'.format(key))
+            fn = os.path.join(self.cache_dir, 'state_{}_{}.pt'.format(key, id(self)))
             self.cached.update({key: fn})
             torch.save(state_dict, fn)
 
@@ -310,7 +310,6 @@ class StateCacher(object):
             if not os.path.exists(fn):
                 raise RuntimeError('Failed to load state in {}. File does not exist anymore.'.format(fn))
             state_dict = torch.load(fn, map_location=lambda storage, location: storage)
-            os.remove(fn)
             return state_dict
 
     def __del__(self):

--- a/lr_finder.py
+++ b/lr_finder.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, with_statement, division
+import copy
 import os
 import torch
 from tqdm.autonotebook import tqdm
@@ -23,7 +24,12 @@ class LRFinder(object):
             optional ordinal for the device type (e.g. "cuda:X", where is the ordinal).
             Alternatively, can be an object representing the device on which the
             computation will take place. Default: None, uses the same device as `model`.
-        cache_dir (string): path for storing temporary files.
+        memory_cache (boolean): if this flag is set to True, `state_dict` of model and
+            optimizer will be cached in memory. Otherwise, they will be saved to files
+            under the `cache_dir`.
+        cache_dir (string): path for storing temporary files. If no path is specified,
+            system-wide temporary directory is used.
+            Notice that this parameter will be ignored if `memory_cache` is True.
 
     Example:
         >>> lr_finder = LRFinder(net, optimizer, criterion, device="cuda")
@@ -34,28 +40,21 @@ class LRFinder(object):
 
     """
 
-    def __init__(self, model, optimizer, criterion, device=None, cache_dir=None):
+    def __init__(self, model, optimizer, criterion, device=None, memory_cache=True, cache_dir=None):
         self.model = model
         self.optimizer = optimizer
         self.criterion = criterion
         self.history = {"lr": [], "loss": []}
         self.best_loss = None
+        self.memory_cache = memory_cache
+        self.cache_dir = cache_dir
 
         # Save the original state of the model and optimizer so they can be restored if
         # needed
-        if cache_dir is None:
-            import tempfile
-            cache_dir = tempfile.gettempdir()
-        else:
-            if not os.path.isdir(cache_dir):
-                raise ValueError('Given `cache_dir` is not a valid directory.')
-
-        self.fn_model_state = os.path.join(cache_dir, 'model_state.pt')
-        self.fn_optimizer_state = os.path.join(cache_dir, 'optimizer_state.pt')
-
         self.model_device = next(self.model.parameters()).device
-        torch.save(model.state_dict(), self.fn_model_state)
-        torch.save(optimizer.state_dict(), self.fn_optimizer_state)
+        self.state_cacher = StateCacher(memory_cache, cache_dir=cache_dir)
+        self.state_cacher.store('model', self.model.state_dict())
+        self.state_cacher.store('optimizer', self.optimizer.state_dict())
 
         # If device is None, use the same as the model
         if device:
@@ -65,15 +64,9 @@ class LRFinder(object):
 
     def reset(self):
         """Restores the model and optimizer to their initial states."""
-        if os.path.exists(self.fn_model_state) and os.path.exists(self.fn_optimizer_state):
-            self.model.load_state_dict(
-                torch.load(self.fn_model_state, map_location=lambda storage, location: storage)
-            )
-            self.optimizer.load_state_dict(
-                torch.load(self.fn_optimizer_state, map_location=lambda storage, location: storage)
-            )
-            os.remove(self.fn_model_state)
-            os.remove(self.fn_optimizer_state)
+        self.model.load_state_dict(self.state_cacher.retrieve('model'))
+        self.optimizer.load_state_dict(self.state_cacher.retrieve('optimizer'))
+        self.model.to(self.model_device)
 
     def range_test(
         self,
@@ -282,3 +275,40 @@ class ExponentialLR(_LRScheduler):
         curr_iter = self.last_epoch + 1
         r = curr_iter / self.num_iter
         return [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]
+
+
+class StateCacher(object):
+    def __init__(self, in_memory, cache_dir=None):
+        self.in_memory = in_memory
+        self.cache_dir = cache_dir
+
+        if self.cache_dir is None:
+            import tempfile
+            self.cache_dir = tempfile.gettempdir()
+        else:
+            if not os.path.isdir(self.cache_dir):
+                raise ValueError('Given `cache_dir` is not a valid directory.')
+
+        self.cached = {}
+
+    def store(self, key, state_dict):
+        if self.in_memory:
+            self.cached.update({key: copy.deepcopy(state_dict)})
+        else:
+            fn = os.path.join(self.cache_dir, 'state_{}.pt'.format(key))
+            self.cached.update({key: fn})
+            torch.save(state_dict, fn)
+
+    def retrieve(self, key):
+        if key not in self.cached:
+            raise KeyError('Target {} was not cached.'.format(key))
+
+        if self.in_memory:
+            return self.cached.pop(key)
+        else:
+            fn = self.cached.pop(key)
+            if not os.path.exists(fn):
+                raise RuntimeError('Failed to load state in {}. File does not exist anymore.'.format(fn))
+            state_dict = torch.load(fn, map_location=lambda storage, location: storage)
+            os.remove(fn)
+            return state_dict


### PR DESCRIPTION
Hi, @davidtvs , sorry for another missed detail in previous pull request.

I notice that file of cached `state_dict` should not be automatically removed when `StateCacher.retrieve()` is called. Otherwise, users cannot get the cached `state_dict` at the second call of `LRFinder.reset()`.

This issue only affect users when they choose to caching `state_dict` with files. And the following code snippet shows how to reproduce this bug (most of the code are same as the content in this [comment](https://github.com/davidtvs/pytorch-lr-finder/pull/1#issuecomment-481334775) ): 

```python
# test_script.py
import torch
import torch.nn as nn
import torch.nn.functional as F
import torch.optim as optim
from torch.utils.data import Subset
from torchvision import datasets, transforms

class ConvNet(nn.Module):
    def __init__(self):
        super(ConvNet, self).__init__()
        # 1,28x28
        self.conv1 = nn.Conv2d(1, 10, 5)  # 10, 24x24
        self.conv2 = nn.Conv2d(10, 20, 3)  # 128, 10x10
        self.fc1 = nn.Linear(20 * 10 * 10, 500)
        self.fc2 = nn.Linear(500, 10)

    def forward(self, x):
        in_size = x.size(0)
        out = self.conv1(x)  # 24
        out = F.relu(out)
        out = F.max_pool2d(out, 2, 2)  # 12
        out = self.conv2(out)  # 10
        out = F.relu(out)
        out = out.view(in_size, -1)
        out = self.fc1(out)
        out = F.relu(out)
        out = self.fc2(out)
        out = F.log_softmax(out, dim=1)  # need nll_loss
        return out

def test_run():
    from lr_finder import LRFinder
    device = torch.device('cuda')
    model = ConvNet()
    model = model.to(device)
    optimizer = optim.Adam(model.parameters())
    criterion = nn.NLLLoss()

    data_folder = './data'
    train_data = datasets.MNIST(data_folder, train=True, download=True,
        transform=transforms.Compose([
            transforms.ToTensor(),
            transforms.Normalize((0.1307,), (0.3081,))
    ]))
    train_data = Subset(train_data, range(1000))
    train_loader = torch.utils.data.DataLoader(
        train_data, batch_size=64, shuffle=True
    )

    lr_finder = LRFinder(model, optimizer, criterion, device=device, memory_cache=False, cache_dir='./data')

    # the first call of `reset()` is fine
    lr_finder.reset()
    # the second call of `reset()` trigger the bug, because file of cached `state_dict` has been removed
    lr_finder.reset()

if __name__ == '__main__':
    test_run()
```

output:
```
~/project/pytorch-lr-finder (master)
$ python test_script.py
Traceback (most recent call last):
  File "test_script.py", line 88, in <module>
    main()
  File "test_script.py", line 55, in main
    lr_finder.reset()
  File "/home/nale/project/pytorch-lr-finder/lr_finder.py", line 67, in reset
    self.model.load_state_dict(self.state_cacher.retrieve('model'))
  File "/home/nale/project/pytorch-lr-finder/lr_finder.py", line 311, in retrieve
    raise RuntimeError('Failed to load state in {}. File does not exist anymore.'.format(fn))
RuntimeError: Failed to load state in ./data/state_model.pt. File does not exist anymore.
```

Besides, I modify the code for creating file name of cached state be suffixed with the id of caller instance (`StateCacher`) in order to prevent multiple `LRFinder` overwriting cached file.