### PR TITLE
Add support for multi-input validation loss

### DIFF
--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -289,11 +289,16 @@ class LRFinder(object):
             for inputs, labels in dataloader:
                 # Move data to the correct device
                 inputs, labels = self._move_to_device(inputs, labels)
+                
+                if isinstance(inputs, tuple) or isinstance(inputs, list):
+                    batch_size = inputs[0].size(0)
+                else:
+                    batch_size = inputs.size(0)
 
                 # Forward pass and loss computation
                 outputs = self.model(inputs)
                 loss = self.criterion(outputs, labels)
-                running_loss += loss.item() * inputs.size(0)
+                running_loss += loss.item() * batch_size
 
         return running_loss / len(dataloader.dataset)
 


### PR DESCRIPTION
The LRFinder will fail when providing a **validation data loader** if the input is a **tuple** or a **list** because it tries to get `input.size(0)`

In this PR I check first if the input is a list or tuple and if so I will get the size of its first element.