### PR TITLE
Allow more object types for model input and labels

### DIFF
--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -273,6 +273,8 @@ class LRFinder(object):
                 return tuple(move(o, device) for o in obj)
             elif isinstance(obj, list):
                 return [move(o, device) for o in obj]
+            elif isinstance(obj, dict):
+                return {k: move(o, device) for k, o in obj.items()}
             else:
                 return obj
 

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -267,10 +267,10 @@ class LRFinder(object):
 
     def _move_to_device(self, inputs, labels):
         def move(obj, device):
-            if isinstance(obj, tuple):
-                return tuple(move(o, device) for o in obj)
-            elif torch.is_tensor(obj):
+            if hasattr(obj, 'to'):
                 return obj.to(device)
+            elif isinstance(obj, tuple):
+                return tuple(move(o, device) for o in obj)
             elif isinstance(obj, list):
                 return [move(o, device) for o in obj]
             else:


### PR DESCRIPTION
Instead of checking whether the object is a tensor, and if it is using `.to()` to move it to the right device, we use duck-typing and utilise the `.to()` method of any object which has one. This means we support higher level torch objects which contain tensors and possess a `.to()` method to move the entire object to a new device.

We also add support for dictionaries, in the same manner as tuples and lists are currently supported (making a new dict containing moved versions of the original contents).