### PR TITLE
Update lr_finder.py

### DIFF
--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -200,8 +200,9 @@ class LRFinder(object):
                 )
 
             # Update the learning rate
+            self.history["lr"].append(lr_schedule.get_last_lr()[0])
+            # print ('lr update after history recording')
             lr_schedule.step()
-            self.history["lr"].append(lr_schedule.get_lr()[0])
 
             # Track the best loss and smooth it if smooth_f is specified
             if iteration == 0:
@@ -397,7 +398,7 @@ class LinearLR(_LRScheduler):
         super(LinearLR, self).__init__(optimizer, last_epoch)
 
     def get_lr(self):
-        curr_iter = self.last_epoch + 1
+        curr_iter = self.last_epoch # + 1
         r = curr_iter / self.num_iter
         return [base_lr + r * (self.end_lr - base_lr) for base_lr in self.base_lrs]
 
@@ -419,7 +420,7 @@ class ExponentialLR(_LRScheduler):
         super(ExponentialLR, self).__init__(optimizer, last_epoch)
 
     def get_lr(self):
-        curr_iter = self.last_epoch + 1
+        curr_iter = self.last_epoch # + 1
         r = curr_iter / self.num_iter
         return [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]
 


### PR DESCRIPTION
I was looking for a pytorch lrfinder. Very nice and thank you for sharing them.

When `lr_finder.history[\'lr\']` was printed out, it did not start with the initial learning rate set in the optimizer declaration. So two things seem to be modified to make it happen.

1. Order change: `get_lr()` before append to history.
2. Function change: `get_last_lr()` to get the latest lr. This seems to be a recent change in pytorch.
```
    self.history["lr"].append(lr_schedule.get_last_lr()[0])
    lr_schedule.step()
```

3.  `self.last_epoch` does not need to be incremented in `ExponentialLR` and `LinearLR` 
```
class ExponentialLR(_LRScheduler):
    def get_lr(self):
        curr_iter = self.last_epoch # + 1
        r = curr_iter / self.num_iter
        return [base_lr * (self.end_lr / base_lr) ** r for base_lr in self.base_lrs]
```
- From inspection, `super().__init__()` calls `step()` within _LRScheduler, then `step()` calls `get_lr()` to update the values. The results are saved in variables in the base class (`_LRScheduler`). 
- The lastly updated learning rate (or list of lrs) are retrieved by `get_last_lr()`. This is reportedly the recent pytorch way of using it.