### PR TITLE
Remove message of checking `apex.amp` module and add tests for features of gradient accumulation/mixed precision training

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,14 @@ accumulation_steps = desired_batch_size // real_batch_size
 dataset = ...
 
 # Beware of the `batch_size` used by `DataLoader`
-trainloader = DataLoader(dataset, batch_size=real_bs, shuffle=True)
+trainloader = DataLoader(dataset, batch_size=real_batch_size, shuffle=True)
 
 model = ...
 criterion = ...
 optimizer = ...
+
+# (Optional) With this setting, `amp.scale_loss()` will be adopted automatically.
+# model, optimizer = amp.initialize(model, optimizer, opt_level='O1')
 
 lr_finder = LRFinder(model, optimizer, criterion, device="cuda")
 lr_finder.range_test(trainloader, end_lr=10, num_iter=100, step_mode="exp", accumulation_steps=accumulation_steps)

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
         "dev": [
             "pytest",
             "pytest-cov",
+            "pytest-mock",
             "flake8",
             "black",
             "pep8-naming",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
     python_requires=">=3.5.9",
     install_requires=["matplotlib", "numpy", "torch>=0.4.1", "tqdm", "packaging"],
     extras_require={
-        "tests": ["pytest", "pytest-cov"],
+        "tests": ["pytest", "pytest-cov", "pytest-mock"],
         "dev": [
             "pytest",
             "pytest-cov",

--- a/tests/task.py
+++ b/tests/task.py
@@ -48,6 +48,8 @@ class BaseTask(metaclass=TaskTemplate):
         elif not isinstance(self.device, torch.device):
             raise TypeError("Invalid type of device.")
 
+        self.model.to(self.device)
+
 
 class XORTask(BaseTask):
     def __init__(self, batch_size=8, steps=100, validate=False):

--- a/tests/task.py
+++ b/tests/task.py
@@ -50,18 +50,25 @@ class BaseTask(metaclass=TaskTemplate):
 
 
 class XORTask(BaseTask):
-    def __init__(self, validate=False):
+    def __init__(self, batch_size=8, steps=100, validate=False):
         super(XORTask, self).__init__()
-        bs, steps = 8, 64
-        dataset = XORDataset(bs * steps)
+        n_total = batch_size * steps
+        dataset = XORDataset(n_total)
         if validate:
-            self.train_loader = DataLoader(Subset(dataset, range(steps - bs)))
-            self.val_loader = DataLoader(Subset(dataset, range(steps - bs, steps)))
+            n_train = int(n_total * 0.9)
+            self.train_loader = DataLoader(
+                Subset(dataset, range(n_train)),
+                batch_size=batch_size
+            )
+            self.val_loader = DataLoader(
+                Subset(dataset, range(n_train, n_total)),
+                batch_size=batch_size
+            )
         else:
-            self.train_loader = DataLoader(dataset)
+            self.train_loader = DataLoader(dataset, batch_size=batch_size)
             self.val_loader = None
 
-        self.batch_size = bs
+        self.batch_size = batch_size
         self.model = LinearMLP([8, 4, 1])
         self.optimizer = optim.SGD(self.model.parameters(), lr=1e-5)
         self.criterion = nn.MSELoss()
@@ -69,17 +76,25 @@ class XORTask(BaseTask):
 
 
 class ExtraXORTask(BaseTask):
-    def __init__(self, validate=False):
+    def __init__(self, batch_size=8, steps=100, validate=False):
         super(ExtraXORTask, self).__init__()
-        bs, steps = 8, 64
-        dataset = ExtraXORDataset(bs * steps, extra_dims=2)
+        n_total = batch_size * steps
+        dataset = ExtraXORDataset(n_total, extra_dims=2)
         if validate:
-            self.train_loader = DataLoader(Subset(dataset, range(steps - bs)))
-            self.val_loader = DataLoader(Subset(dataset, range(steps - bs, steps)))
+            n_train = int(n_total * 0.9)
+            self.train_loader = DataLoader(
+                Subset(dataset, range(n_train)),
+                batch_size=batch_size
+            )
+            self.val_loader = DataLoader(
+                Subset(dataset, range(n_train, n_total)),
+                batch_size=batch_size
+            )
         else:
-            self.train_loader = DataLoader(dataset)
+            self.train_loader = DataLoader(dataset, batch_size=batch_size)
             self.val_loader = None
 
+        self.batch_size = batch_size
         self.model = LinearMLP([8, 4, 1])
         self.optimizer = optim.SGD(self.model.parameters(), lr=1e-5)
         self.criterion = nn.MSELoss()
@@ -87,18 +102,25 @@ class ExtraXORTask(BaseTask):
 
 
 class DiscriminativeLearningRateTask(BaseTask):
-    def __init__(self, validate=False):
+    def __init__(self, batch_size=8, steps=100, validate=False):
         super(DiscriminativeLearningRateTask, self).__init__()
-        bs, steps = 8, 64
-        dataset = XORDataset(bs * steps)
+        n_total = batch_size * steps
+        dataset = XORDataset(n_total)
         if validate:
-            self.train_loader = DataLoader(Subset(dataset, range(steps - bs)))
-            self.val_loader = DataLoader(Subset(dataset, range(steps - bs, steps)))
+            n_train = int(n_total * 0.9)
+            self.train_loader = DataLoader(
+                Subset(dataset, range(n_train)),
+                batch_size=batch_size
+            )
+            self.val_loader = DataLoader(
+                Subset(dataset, range(n_train, n_total)),
+                batch_size=batch_size
+            )
         else:
-            self.train_loader = DataLoader(dataset)
+            self.train_loader = DataLoader(dataset, batch_size=batch_size)
             self.val_loader = None
 
-        dataset = XORDataset(128)
+        self.batch_size = batch_size
         self.model = LinearMLP([8, 4, 1])
         self.optimizer = optim.SGD(
             [

--- a/tests/test_lr_finder.py
+++ b/tests/test_lr_finder.py
@@ -5,11 +5,11 @@ import task as mod_task
 
 
 try:
-    import apex
+    from apex import amp
 
-    IS_APEX_AVAILABLE = True
+    IS_AMP_AVAILABLE = True
 except ImportError:
-    IS_APEX_AVAILABLE = False
+    IS_AMP_AVAILABLE = False
 
 
 def collect_task_classes():
@@ -117,12 +117,10 @@ class TestGradientAccumulation:
         assert spy.call_count == accum_steps * num_iter
 
     @pytest.mark.skipif(
-        not (IS_APEX_AVAILABLE and mod_task.use_cuda()),
+        not (IS_AMP_AVAILABLE and mod_task.use_cuda()),
         reason="`apex` module and gpu is required to run this test."
     )
     def test_gradient_accumulation_with_apex_amp(self, mocker):
-        from apex import amp
-
         desired_bs, accum_steps = 32, 4
         real_bs = desired_bs // accum_steps
         num_iter = 10
@@ -144,13 +142,11 @@ class TestGradientAccumulation:
 
 
 @pytest.mark.skipif(
-    not (IS_APEX_AVAILABLE and mod_task.use_cuda()),
+    not (IS_AMP_AVAILABLE and mod_task.use_cuda()),
     reason="`apex` module and gpu is required to run these tests."
 )
 class TestMixedPrecision:
     def test_mixed_precision(self, mocker):
-        from apex import amp
-
         batch_size = 32
         num_iter = 10
         task = mod_task.XORTask(batch_size=batch_size)

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -15,17 +15,7 @@ try:
 
     IS_AMP_AVAILABLE = True
 except ImportError:
-    import logging
-
-    logging.basicConfig()
-    logger = logging.getLogger(__name__)
-    logger.warning(
-        "To enable mixed precision training, please install `apex`. "
-        "Or you can re-install this package by the following command:\n"
-        '  pip install torch-lr-finder -v --global-option="amp"'
-    )
     IS_AMP_AVAILABLE = False
-    del logging
 
 
 class DataLoaderIter(object):


### PR DESCRIPTION
This PR is a fix for issue #45 with some new test cases for those features implemented in PR #9.

A quick summary for this PR:
1. The message `To enable mixed precision training, please install apex...` is removed. (solved in commit 227fc53)
2. A silly mistake was made. `batch_size` was not passed into `DataLoader`, so that those data loaders in test cases were working with the default value `batch_size=1` before. Though it does not affect the test correctness, it still needs to be corrected. (solved in commit 1c549ec)
3. Another mistake. In test cases, there is no setting that moves model to device declared in `task.__init__()`. Therefore, all tests were running on CPU even if the pytest argument `--cpu_only` is not specified. (solved in commit c854714)
4. More tests for features of gradient accumulation and mixed precision are added in commit e073ac8.

Note that there is a new dependency `pytest-mock` added for new test cases.