### PR TITLE
Make `ValDataLoaderIter` able to be reset only when it is acquired by the syntax of normal `iterator`

### DIFF
--- a/tests/dataset.py
+++ b/tests/dataset.py
@@ -93,3 +93,15 @@ class SimplePOSTaggerDataset(Dataset):
 
     def __len__(self):
         return len(self.data)
+
+
+class RandomDataset(Dataset):
+    def __init__(self, length):
+        self.data = torch.rand((length, 4))
+        self.label = torch.rand((length, 1))
+
+    def __getitem__(self, index):
+        return self.data[index], self.label[index]
+
+    def __len__(self):
+        return len(self.data)

--- a/tests/test_lr_finder.py
+++ b/tests/test_lr_finder.py
@@ -1,7 +1,12 @@
 import pytest
+from torch.utils.data import DataLoader
 from torch_lr_finder import LRFinder
+from torch_lr_finder.lr_finder import (
+    DataLoaderIter, TrainDataLoaderIter, ValDataLoaderIter
+)
 
 import task as mod_task
+import dataset as mod_dataset
 
 import matplotlib.pyplot as plt
 
@@ -36,6 +41,33 @@ def prepare_lr_finder(task, **kwargs):
 
 def get_optim_lr(optimizer):
     return [grp["lr"] for grp in optimizer.param_groups]
+
+
+def run_loader_iter(loader_iter, desired_runs=None):
+    """Run a `DataLoaderIter` object for specific times.
+
+    Arguments:
+        loader_iter (torch_lr_finder.DataLoaderIter): the iterator to test.
+        desired_runs (int, optional): times that iterator should be iterated.
+            If it's not given, `len(loader_iter.data_loader)` will be used.
+
+    Returns:
+        is_achieved (bool): False if `loader_iter` cannot be iterated specific
+            times. It usually means `loader_iter` has raised `StopIteration`.
+    """
+    assert isinstance(loader_iter, DataLoaderIter)
+
+    if desired_runs is None:
+        desired_runs = len(loader_iter.data_loader)
+
+    count = 0
+    try:
+        for i in range(desired_runs):
+            next(loader_iter)
+            count += 1
+    except StopIteration:
+        return False
+    return desired_runs == count
 
 
 class TestRangeTest:
@@ -189,6 +221,43 @@ class TestMixedPrecision:
         # NOTE: Here we did not perform gradient accumulation, so that call count
         # of `amp.scale_loss` should equal to `num_iter`.
         assert spy.call_count == num_iter
+
+
+class TestDataLoaderIter:
+    def test_traindataloaderiter(self):
+        batch_size, data_length = 32, 256
+        dataset = mod_dataset.RandomDataset(256)
+        dataloader = DataLoader(dataset, batch_size=batch_size)
+
+        loader_iter = TrainDataLoaderIter(dataloader)
+
+        assert run_loader_iter(loader_iter)
+
+        # `TrainDataLoaderIter` can reset itself, so that it's ok to reuse it
+        # directly and iterate it more than `len(dataloader)` times.
+        assert run_loader_iter(loader_iter, desired_runs=len(dataloader) + 1)
+
+
+    def test_valdataloaderiter(self):
+        batch_size, data_length = 32, 256
+        dataset = mod_dataset.RandomDataset(256)
+        dataloader = DataLoader(dataset, batch_size=batch_size)
+
+        loader_iter = ValDataLoaderIter(dataloader)
+
+        assert run_loader_iter(loader_iter)
+
+        # `ValDataLoaderIter` can't reset itself, so this should be False if
+        # we re-run it without resetting it.
+        assert not run_loader_iter(loader_iter)
+
+        # Reset it by `iter()`
+        loader_iter = iter(loader_iter)
+        assert run_loader_iter(loader_iter)
+
+        # `ValDataLoaderIter` can't be iterated more than `len(dataloader)` times
+        loader_iter = ValDataLoaderIter(dataloader)
+        assert not run_loader_iter(loader_iter, desired_runs=len(dataloader) + 1)
 
 
 @pytest.mark.parametrize("num_iter", [0, 1])

--- a/tests/test_lr_finder.py
+++ b/tests/test_lr_finder.py
@@ -292,7 +292,7 @@ class TestDataLoaderIter:
 
         loader_iter = CustomLoaderIter(task.train_loader)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="`train_loader` has unsupported type"):
             lr_finder.range_test(loader_iter, num_iter=num_iter)
 
     def test_run_range_test_with_valloaderiter_without_subclassing(self):
@@ -303,7 +303,7 @@ class TestDataLoaderIter:
         train_loader_iter = TrainDataLoaderIter(task.train_loader)
         val_loader_iter = CustomLoaderIter(task.val_loader)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="`val_loader` has unsupported type"):
             lr_finder.range_test(
                 train_loader_iter, val_loader=val_loader_iter, num_iter=num_iter
             )

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -87,7 +87,7 @@ class ValDataLoaderIter(DataLoaderIter):
         loader_iter = iter(loader_iter)  # __iter__ is called by `iter()`
         ```
     """
-    def __init__(self, data_loader, auto_reset=True):
+    def __init__(self, data_loader):
         super().__init__(data_loader)
         self.run_limit = len(self.data_loader)
         self.run_counter = 0

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -68,7 +68,39 @@ class TrainDataLoaderIter(DataLoaderIter):
 
 
 class ValDataLoaderIter(DataLoaderIter):
-    pass
+    """This iterator will reset itself **only** when it is acquired by
+    the syntax of normal `iterator`. That is, this iterator just works
+    like a `torch.data.DataLoader`. If you want to restart it, you
+    should use it like:
+
+        ```
+        loader_iter = ValDataLoaderIter(data_loader)
+        for batch in loader_iter:
+            ...
+
+        # `loader_iter` should run out of values now, you can restart it by:
+        # 1. the way we use a `torch.data.DataLoader`
+        for batch in loader_iter:        # __iter__ is called implicitly
+            ...
+
+        # 2. passing it into `iter()` manually
+        loader_iter = iter(loader_iter)  # __iter__ is called by `iter()`
+        ```
+    """
+    def __init__(self, data_loader, auto_reset=True):
+        super().__init__(data_loader)
+        self.run_limit = len(self.data_loader)
+        self.run_counter = 0
+
+    def __iter__(self):
+        if self.run_counter >= self.run_limit:
+            self._iterator = iter(self.data_loader)
+            self.run_counter = 0
+        return self
+
+    def __next__(self):
+        self.run_counter += 1
+        return super(ValDataLoaderIter, self).__next__()
 
 
 class LRFinder(object):


### PR DESCRIPTION
`ValDataLoaderIter` is not reset after each iteration, and it results in the problem shown in issue #59.
See also this comment: https://github.com/davidtvs/pytorch-lr-finder/issues/59#issuecomment-668631184 for further details.

In this PR, tests related to `TrainDataLoaderIter` and `ValDataLoaderIter` are also added.

---
UPDATE:

Purpose of the changes in this PR is to make `ValDataLoader` work like `torch.data.DataLoader`. When we want to iterate over a `torch.data.DataLoader`, we can use the following approaches:

1. iterate it through a for-loop
   (`DataLoader.__iter__()` is called implicitly by for loop)
    ```python
    data_loader = DataLoader(dataset)
    for batch in data_loader:
        ...

    # This is OK since an iterator will be create each time `data_loader`
    # is used in a for-loop.
    for batch in data_loader:
        ...
    ```

2. iterate it through an iterator created by `iter()`
    ```python
    loader_iter = iter(data_loader)
    for i in len(data_loader):
        batch = next(loader_iter)
        ...

    # `loader_iter` should runs out of values now, so that the following
    # operation will trigger the exception `StopIteration`.
    next(loader_iter)
    ```

And the first approach is how we use `val_loader` before commit 52c189a. An iterator of `val_loader` will be created whenever it is iterated through the for-loop in `self._validate()`.

https://github.com/davidtvs/pytorch-lr-finder/blob/ed2182523bb3175bbf61dcf7b354d976fcb0ee65/torch_lr_finder/lr_finder.py#L197-L200


In commit 52c189a, `ValDataLoaderIter` was introduced to solve the problem of unpacking multiple values returned by a data loader. However, since an instance of `ValDataLoaderIter` is created, the iterator we can acquire by either a for-loop or `iter()` is always the same object (i.e. `ValDataLoaderIter()` itself). That means it can't be reset by those approaches mentioned above, and that's why it makes `self._validate()` failed to work as before.

With the changes made in this PR, `ValDataLoaderIter` should work like how we use `torch.data.DataLoader`.


Besides, the reason why we didn't just apply these changes to `DataLoaderIter` is that `TrainDataLoaderIter` relies on it's behavior. Since `TrainDataLoaderIter` should be capable of resetting itself when `auto_reset` is True, it should return itself when we acquire an iterator through `TrainDataLoaderIter.__iter__()`.