### PR TITLE
Explicitly check whether `min_grad_idx` is `None` or not before returning in `lr_finder.plot()`

### DIFF
--- a/tests/test_lr_finder.py
+++ b/tests/test_lr_finder.py
@@ -372,3 +372,21 @@ def test_suggest_lr():
     ax, lr = lr_finder.plot(skip_start=0, skip_end=0, suggest_lr=True, ax=ax)
 
     assert lr == 2
+
+    # Loss with minimal gradient is the first element in history
+    lr_finder.history["loss"] = [1, 0, 1, 2, 3, 4]
+    lr_finder.history["lr"] = range(len(lr_finder.history["loss"]))
+
+    fig, ax = plt.subplots()
+    ax, lr = lr_finder.plot(skip_start=0, skip_end=0, suggest_lr=True, ax=ax)
+
+    assert lr == 0
+
+    # Loss with minimal gradient is the last element in history
+    lr_finder.history["loss"] = [0, 1, 2, 3, 4, 3]
+    lr_finder.history["lr"] = range(len(lr_finder.history["loss"]))
+
+    fig, ax = plt.subplots()
+    ax, lr = lr_finder.plot(skip_start=0, skip_end=0, suggest_lr=True, ax=ax)
+
+    assert lr == len(lr_finder.history["loss"]) - 1

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -532,7 +532,7 @@ class LRFinder(object):
         if fig is not None:
             plt.show()
 
-        if suggest_lr and min_grad_idx:
+        if suggest_lr and min_grad_idx is not None:
             return ax, lrs[min_grad_idx]
         else:
             return ax


### PR DESCRIPTION
@davidtvs, @chAwater
This is a fix for #65, and I've added related test cases for it.

Feel free to let me know if anything is missing.