### PR TITLE
Make both `torch.amp` and `apex.amp` available as backend for mixed precision training

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,21 +105,40 @@ lr_finder.reset()
 
 ### Mixed precision training
 
-Currently, we use [`apex`](https://github.com/NVIDIA/apex) as the dependency for mixed precision training.
-To enable mixed precision training, you just need to call `amp.initialize()` before running `LRFinder`. e.g.
+Both `apex.amp` and `torch.amp` are supported now, here are the examples:
 
-```python
-from torch_lr_finder import LRFinder
-from apex import amp
+- Using [`apex.amp`](https://github.com/NVIDIA/apex):
+    ```python
+    from torch_lr_finder import LRFinder
+    from apex import amp
 
-# Add this line before running `LRFinder`
-model, optimizer = amp.initialize(model, optimizer, opt_level='O1')
+    # Add this line before running `LRFinder`
+    model, optimizer = amp.initialize(model, optimizer, opt_level='O1')
 
-lr_finder = LRFinder(model, optimizer, criterion, device='cuda')
-lr_finder.range_test(trainloader, end_lr=10, num_iter=100, step_mode='exp')
-lr_finder.plot()
-lr_finder.reset()
-```
+    lr_finder = LRFinder(model, optimizer, criterion, device='cuda', amp_backend='apex')
+    lr_finder.range_test(trainloader, end_lr=10, num_iter=100, step_mode='exp')
+    lr_finder.plot()
+    lr_finder.reset()
+    ```
+
+- Using [`torch.amp`](https://pytorch.org/docs/stable/notes/amp_examples.html)
+    ```python
+    from torch_lr_finder import LRFinder
+
+    amp_config = {
+        'device_type': 'cuda',
+        'dtype': torch.float16,
+    }
+    grad_scaler = torch.cuda.amp.GradScaler()
+
+    lr_finder = LRFinder(
+        model, optimizer, criterion, device='cuda',
+        amp_backend='torch', amp_config=amp_config, grad_scaler=grad_scaler
+    )
+    lr_finder.range_test(trainloader, end_lr=10, num_iter=100, step_mode='exp')
+    lr_finder.plot()
+    lr_finder.reset()
+    ```
 
 Note that the benefit of mixed precision training requires a nvidia GPU with tensor cores (see also: [NVIDIA/apex #297](https://github.com/NVIDIA/apex/issues/297))
 

--- a/examples/mnist_with_amp.py
+++ b/examples/mnist_with_amp.py
@@ -1,0 +1,219 @@
+"""
+Train a simple neural net for MNIST dataset with mixed precision training.
+
+Examples
+--------
+- Run with `torch.amp`:
+    ```bash
+    $ python mnist_with_amp.py --batch_size=32 --seed=42 --tqdm --amp_backend=torch
+    ```
+- Run without mixed precision training:
+    ```bash
+    $ python mnist_with_amp.py --batch_size=32 --seed=42 --tqdm --amp_backend=""
+    ```
+"""
+
+from argparse import ArgumentParser
+import random
+import sys
+import os
+import time
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torch.utils.data import Subset, DataLoader
+from torchvision import datasets, transforms
+
+from torch_lr_finder import LRFinder
+from apex import amp
+
+
+SEED = 0
+
+def reset_seed(seed):
+    """
+    ref: https://forums.fast.ai/t/accumulating-gradients/33219/28
+    """
+    random.seed(seed)
+    os.environ['PYTHONHASHSEED'] = str(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.backends.cudnn.deterministic = True
+
+
+def simple_timer(func):
+    def wrapper(*args, **kwargs):
+        st = time.time()
+        func(*args, **kwargs)
+        print('--- Time taken from {}: {} seconds'.format(
+            func.__qualname__, time.time() - st
+        ))
+    return wrapper
+
+
+# redirect output from tqdm
+def conceal_stdout(enabled):
+    if enabled:
+        f = open(os.devnull, 'w')
+        sys.stdout = f
+        sys.stderr = f
+    else:
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+
+class ConvNet(nn.Module):
+    def __init__(self):
+        super(ConvNet, self).__init__()
+        self.conv1 = nn.Conv2d(1, 16, kernel_size=5, stride=1)
+        self.conv2 = nn.Conv2d(16, 32, kernel_size=3, stride=1)
+        self.conv2_drop = nn.Dropout2d()
+        self.net = nn.Sequential(
+            self.conv1,  # (24, 24, 16)
+            nn.MaxPool2d(2),  # (12, 12, 16)
+            nn.ReLU(True),
+            self.conv2,  # (10, 10, 32)
+            self.conv2_drop,
+            nn.MaxPool2d(2),  # (5, 5, 32)
+            nn.ReLU(True),
+        )
+        self.fc1 = nn.Linear(5*5*32, 64)
+        self.fc2 = nn.Linear(64, 16)
+
+    def forward(self, x):
+        x = self.net(x)
+        x = x.view(-1, 5*5*32)
+        x = F.relu(self.fc1(x))
+        x = F.dropout(x, training=self.training)
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+@simple_timer
+def warm_up(trainset):
+    trainloader = DataLoader(trainset, batch_size=256, shuffle=True)
+
+    device = torch.device('cuda')
+    model = ConvNet()
+    model = model.to(device)
+    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.5)
+    criterion = nn.NLLLoss()
+
+    conceal_stdout(True)
+    lr_finder = LRFinder(model, optimizer, criterion, device='cuda')
+    lr_finder.range_test(trainloader, end_lr=10, num_iter=10, step_mode='exp')
+    conceal_stdout(False)
+
+
+@simple_timer
+def run_normal(trainset, batch_size, no_tqdm=True):
+    trainloader = DataLoader(trainset, batch_size=batch_size, shuffle=True)
+
+    device = torch.device('cuda')
+    model = ConvNet()
+    model = model.to(device)
+    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.5)
+    criterion = nn.NLLLoss()
+
+    conceal_stdout(no_tqdm)
+    lr_finder = LRFinder(model, optimizer, criterion, device='cuda')
+    lr_finder.range_test(trainloader, end_lr=10, num_iter=100, step_mode='exp')
+    lr_finder.plot()
+    conceal_stdout(no_tqdm and False)
+
+
+@simple_timer
+def run_amp_apex(trainset, batch_size, no_tqdm=True, opt_level='O1'):
+    trainloader = DataLoader(trainset, batch_size=batch_size, shuffle=True)
+
+    device = torch.device('cuda')
+    model = ConvNet()
+    model = model.to(device)
+    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.5)
+    criterion = nn.NLLLoss()
+
+    model, optimizer = amp.initialize(model, optimizer, opt_level=opt_level)
+
+    conceal_stdout(no_tqdm)
+    lr_finder = LRFinder(model, optimizer, criterion, device='cuda', amp_backend='apex')
+    lr_finder.range_test(trainloader, end_lr=10, num_iter=100, step_mode='exp')
+    lr_finder.plot()
+    conceal_stdout(no_tqdm and False)
+
+@simple_timer
+def run_amp_torch(trainset, batch_size, no_tqdm=True):
+    trainloader = DataLoader(trainset, batch_size=batch_size, shuffle=True)
+
+    device = torch.device('cuda')
+    model = ConvNet()
+    model = model.to(device)
+    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.5)
+    criterion = nn.NLLLoss()
+
+    amp_config = {
+        'device_type': 'cuda',
+        'dtype': torch.float16,
+    }
+    grad_scaler = torch.cuda.amp.GradScaler()
+
+    conceal_stdout(no_tqdm)
+    lr_finder = LRFinder(
+        model, optimizer, criterion,
+        amp_backend='torch', amp_config=amp_config, grad_scaler=grad_scaler
+    )
+    lr_finder.range_test(trainloader, end_lr=10, num_iter=100, step_mode='exp')
+    lr_finder.plot()
+    conceal_stdout(no_tqdm and False)
+
+def parse_args():
+    parser = ArgumentParser(add_help=True)
+    parser.add_argument('--amp_backend', type=str, default='',
+                        help='Backend for auto-mixed precision training, available: '
+                        '[torch, apex]. If not specified, amp is disabled.')
+    parser.add_argument('--batch_size', type=int, default=32)
+    parser.add_argument('--seed', type=int, default=0, help='Random seed.')
+    parser.add_argument('--data_folder', type=str, default='./data',
+                        help='Location of MNIST dataset.')
+    parser.add_argument('--cudnn_benchmark', action='store_true',
+                        help='Add this flag to make cudnn auto-tuner able to find '
+                        'the best algorithm on your machine. This may improve the '
+                        'performance when you are running script of mixed precision '
+                        'training.')
+    parser.add_argument('--tqdm', action='store_true',
+                        help='Add this flag to show the output from tqdm.')
+    parser.add_argument('--warm_up', action='store_true',
+                        help='Add this flag to run a warm-up snippet.')
+    parser.add_argument('--opt_level', type=str, default='O1',
+                        help='Optimization level for amp. (works only for `apex`)')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    # turn this mode on may improve the performance on some GPUs
+    torch.backends.cudnn.benchmark = args.cudnn_benchmark
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.1307,), (0.3081,))
+    ])
+    trainset = datasets.MNIST(args.data_folder, train=True, download=True, transform=transform)
+
+    reset_seed(args.seed)
+    if args.warm_up:
+        warm_up(trainset)
+
+    if args.amp_backend == '':
+        run_normal(trainset, args.batch_size, no_tqdm=not args.tqdm)
+    elif args.amp_backend == 'apex':
+        run_amp_apex(trainset, args.batch_size, no_tqdm=not args.tqdm, opt_level=args.opt_level)
+    elif args.amp_backend == 'torch':
+        run_amp_torch(trainset, args.batch_size, no_tqdm=not args.tqdm)
+    else:
+        print(f'Unknown amp backend: {args.amp_backend}')
+

--- a/examples/mnist_with_amp.py
+++ b/examples/mnist_with_amp.py
@@ -215,5 +215,5 @@ if __name__ == '__main__':
     elif args.amp_backend == 'torch':
         run_amp_torch(trainset, args.batch_size, no_tqdm=not args.tqdm)
     else:
-        print(f'Unknown amp backend: {args.amp_backend}')
+        print('Unknown amp backend: {}'.format(args.amp_backend))
 

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -177,11 +177,11 @@ class LRFinder(object):
 
         # Settings related to mixed precision training
         if amp_backend and (amp_backend not in AVAILABLE_AMP_BACKENDS):
-            raise ValueError(f"Unknown amp backend: {amp_backend}")
+            raise ValueError("Unknown amp backend: {}".format(amp_backend))
 
         if amp_backend == "torch":
             if grad_scaler is None:
-                raise ValueError(f"`grad_scaler` is required when using `torch.amp`")
+                raise ValueError("`grad_scaler` is required when using `torch.amp`")
 
         self.amp_backend = amp_backend
         self.amp_config = amp_config

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -417,13 +417,7 @@ class LRFinder(object):
             if self.amp_backend == "torch":
                 self.grad_scaler.scale(loss).backward()
             elif self.amp_backend == "apex" and hasattr(self.optimizer, "_amp_stash"):
-                # For minor performance optimization, see also:
-                # https://nvidia.github.io/apex/advanced.html#gradient-accumulation-across-iterations
-                delay_unscale = ((i + 1) % accumulation_steps) != 0
-
-                with apex.amp.scale_loss(
-                    loss, self.optimizer, delay_unscale=delay_unscale
-                ) as scaled_loss:
+                with apex.amp.scale_loss(loss, self.optimizer) as scaled_loss:
                     scaled_loss.backward()
             else:
                 loss.backward()


### PR DESCRIPTION
Hi @davidtvs, here is a summary of changes made in this PR for issue #67, #90.

## Required changes to integrate `torch.amp`
- `torch.cuda.amp.GradScaler` has to be passed into `LRFinder`, because it's will be used in the following stages:
  - backward pass:
    ```python
    # without AMP (automatic precision training), or using `apex.amp`
    loss.backward()
    
    # using `torch.amp`
    scaler.scale(loss).backward()
    ```
  - optimizer steps:
    ```python
    # without AMP, or using `apex.amp`
    optimizer.step()
    
    # using `torch.amp`
    scaler.step(optimizer)
    scaler.update()
    ```
- `torch.amp.autocast()` need to be called in forward pass:
  ```python
  # without AMP, or using `apex.amp`
  outputs = self.model(inputs)
  loss = self.criterion(outputs, labels)
  
  # using `torch.amp`
  with torch.amp.autocast(device_type=..., dtype=...):
    outputs = self.model(inputs)
    loss = self.criterion(outputs, labels)
  ```

## Proposed changes
3 new keyword arguments are added to `LRFinder.__init__()`:
- `amp_backend`: a string to select AMP backend
- `amp_config`: a dict to store arguments required by `torch.amp.autocast()`
- `grad_scaler`: a `torch.cuda.amp.GradScaler` instance to be used in `LRFinder._train_batch()`

This should maximize the flexibility for user to control how AMP works with `LRFinder`.

If there is a need to apply advanced tricks with `torch.amp` (e.g., for multi-GPUs/models/losses [1][1]), it's still achievable by just overriding `LRFinder._train_batch()`. So we can focus on the current implementation for gradient accumulation without worrying about other variants.

## Note
The new script `examples/mnist_with_amp.py` can be used to check the results produced by running `LRFinder` with different AMP backends. Here are the results produced on my machine with command `$ python mnist_with_amp.py --batch_size=32 --tqdm --amp_backend=...`:

|![][mnist_amp_none]|![][mnist_amp_apex]|![][mnist_amp_torch]|
|:-:|:-:|:-:|
|without AMP|`apex.amp`|`torch.amp`|

\* In these 3 figures, suggested LRs are all the same one: 2.42E-01

Package information:
- python: 3.9.18
- torch: 1.13.1+cu117
- apex: 0.1 (compiled from source, and I need to checkout to revision `2386a912164b0c5cfcd8be7a2b890fbac5607c82` to build. see also [this comment][apex_build_issue])

As always, feel free to let me know if there is anything can be improved.

<!-- links -->
[1]: https://pytorch.org/docs/stable/notes/amp_examples.html#working-with-multiple-models-losses-and-optimizers
[mnist_amp_none]: https://github.com/davidtvs/pytorch-lr-finder/assets/7083478/3a17c618-2490-4ece-9efa-dc12523a9470
[mnist_amp_apex]: https://github.com/davidtvs/pytorch-lr-finder/assets/7083478/f02de233-8a2c-4c97-bcd9-3afe1293afba
[mnist_amp_torch]: https://github.com/davidtvs/pytorch-lr-finder/assets/7083478/1f36e205-c83e-4027-bb61-5d3137ab6e91
[apex_build_issue]: https://github.com/NVIDIA/apex/issues/1735#issuecomment-1743179030