### PR TITLE
Prevent unexpected unpacking error when calling `lr_finder.plot()` with `suggest_lr=True`

### DIFF
--- a/tests/test_lr_finder.py
+++ b/tests/test_lr_finder.py
@@ -401,9 +401,21 @@ def test_plot_with_skip_and_suggest_lr(suggest_lr, skip_start, skip_end):
     )
 
     fig, ax = plt.subplots()
-    results = lr_finder.plot(
-        skip_start=skip_start, skip_end=skip_end, suggest_lr=suggest_lr, ax=ax
-    )
+
+    results = None
+    if suggest_lr and num_iter < (skip_start + skip_end + 2):
+        # No sufficient data points to calculate gradient, so this call should fail
+        with pytest.raises(RuntimeError, match="Need at least"):
+            results = lr_finder.plot(
+                skip_start=skip_start, skip_end=skip_end, suggest_lr=suggest_lr, ax=ax
+            )
+
+        # No need to proceed then
+        return
+    else:
+        results = lr_finder.plot(
+            skip_start=skip_start, skip_end=skip_end, suggest_lr=suggest_lr, ax=ax
+        )
 
     # NOTE:
     # - ax.lines[0]: the lr-loss curve. It should be always available once

--- a/tests/test_lr_finder.py
+++ b/tests/test_lr_finder.py
@@ -8,6 +8,7 @@ from torch_lr_finder.lr_finder import (
 import task as mod_task
 import dataset as mod_dataset
 
+import numpy as np
 import matplotlib.pyplot as plt
 
 # Check available backends for mixed precision training
@@ -404,17 +405,52 @@ def test_plot_with_skip_and_suggest_lr(suggest_lr, skip_start, skip_end):
         skip_start=skip_start, skip_end=skip_end, suggest_lr=suggest_lr, ax=ax
     )
 
-    if num_iter - skip_start - skip_end <= 1:
-        # handle data with one or zero lr
-        assert len(ax.lines) == 1
-        assert results is ax
+    # NOTE:
+    # - ax.lines[0]: the lr-loss curve. It should be always available once
+    #   `ax.plot(lrs, losses)` is called. But when there is no sufficent data
+    #   point (num_iter <= skip_start + skip_end), the coordinates will be
+    #   2 empty arrays.
+    # - ax.collections[0]: the point of suggested lr (type: <PathCollection>).
+    #   It's available only when there are sufficient data points to calculate
+    #   gradient of lr-loss curve.
+    assert len(ax.lines) == 1
+
+    if suggest_lr:
+        assert isinstance(results, tuple) and len(results) == 2
+
+        ret_ax, ret_lr = results
+        assert ret_ax is ax
+
+        # XXX: Currently suggested lr is selected according to gradient of
+        # lr-loss curve, so there should be at least 2 valid data points (after
+        # filtered by `skip_start` and `skip_end`). If not, the returned lr
+        # will be None.
+        # But we would need to rework on this if there are more suggestion
+        # methods is supported in the future.
+        if num_iter - skip_start - skip_end <= 1:
+            assert ret_lr is None
+            assert len(ax.collections) == 0
+        else:
+            assert len(ax.collections) == 1
     else:
-        # handle different suggest_lr
-        # for 'steepest': the point with steepest gradient (minimal gradient)
-        assert len(ax.lines) == 1
-        assert len(ax.collections) == int(suggest_lr)
-        if results is not ax:
-            assert len(results) == 2
+        # Not suggesting lr, so it just plots a lr-loss curve.
+        assert results is ax
+        assert len(ax.collections) == 0
+
+    # Check whether the data of plotted line is the same as the one filtered
+    # according to `skip_start` and `skip_end`.
+    lrs = np.array(lr_finder.history["lr"])
+    losses = np.array(lr_finder.history["loss"])
+    x, y = ax.lines[0].get_data()
+
+    # If skip_end is 0, we should replace it with None. Otherwise, it
+    # will create a slice as `x[0:-0]` which is an empty list.
+    _slice = slice(skip_start, -skip_end if skip_end != 0 else None, None)
+    assert np.allclose(x, lrs[_slice])
+    assert np.allclose(y, losses[_slice])
+
+    # Close figure to release memory
+    plt.close()
 
 
 def test_suggest_lr():

--- a/torch_lr_finder/lr_finder.py
+++ b/torch_lr_finder/lr_finder.py
@@ -538,7 +538,8 @@ class LRFinder(object):
                 min_grad_idx = (np.gradient(np.array(losses))).argmin()
             except ValueError:
                 print(
-                    "Failed to compute the gradients, there might not be enough points."
+                    "Failed to compute the gradients, there might not be enough points. "
+                    "Please check whether num_iter >= (skip_start + skip_end + 2)."
                 )
             if min_grad_idx is not None:
                 print("Suggested LR: {:.2E}".format(lrs[min_grad_idx]))
@@ -565,8 +566,10 @@ class LRFinder(object):
         if fig is not None:
             plt.show()
 
-        if suggest_lr and min_grad_idx is not None:
-            return ax, lrs[min_grad_idx]
+        if suggest_lr:
+            # If suggest_lr is set, then we should always return 2 values.
+            suggest_lr = None if min_grad_idx is None else lrs[min_grad_idx]
+            return ax, suggest_lr
         else:
             return ax
 


### PR DESCRIPTION
@davidtvs, this PR should fix #88. And if it is resolved, maybe we can go on #97 to make a new release to PyPI.
@chAwater, I've rewritten part of the test case you made, please feel free to advise me if there is anything can be improved.

## Problem
When calling `lr_finder.plot(..., suggest_lr=True)`, we usually expect the returned value is actually a tuple containing `ax` and `suggested_lr`, and the API is also [described as it](https://github.com/davidtvs/pytorch-lr-finder/blob/fd9e949bc709e31881c77a4b0710745524c5091e/torch_lr_finder/lr_finder.py#L501-L503).

But it would return only `ax` if there is no sufficient data points to calculate gradient of lr-loss curve:
https://github.com/davidtvs/pytorch-lr-finder/blob/fd9e949bc709e31881c77a4b0710745524c5091e/torch_lr_finder/lr_finder.py#L536-L542
https://github.com/davidtvs/pytorch-lr-finder/blob/fd9e949bc709e31881c77a4b0710745524c5091e/torch_lr_finder/lr_finder.py#L568-L571

Therefore, if users prefer unpacking the returned value directly as below, they would sometimes ran into the error `TypeError: cannot unpack non-iterable AxesSubplot object`.
```python
ax, suggested_lr = lr_finder.plot(ax=ax, suggest_lr=True)
```

## Solution
Always return 2 values if `suggest_lr=True`. This makes sure it work with the 2 kinds of syntax as follows:
```python
# 1. unpack returned value directly
ax, suggested_lr = lr_finder.plot(ax=ax, suggest_lr=True)

# 2. use a single variable to catch the returned value, then unpack them manually (user can check it before unpacking)
retval = lr_finder.plot(ax=ax, suggest_lr=True)
assert isinstance(retval, tuple) and len(retval) == 2
ax, suggested_lr = retval
```

The responsibility of "check whether `suggested_lr` is available/none" is left back to users now. But it should be fine since the warning message would show up and it's easy to check. Also, the warning message is now [more verbose][pr_content_01] to help user figure out the problem.

## Note
Though I think this issue could be resolved better by separating the feature of "suggest learning rate" into a new function, it should be safer to keep the API unchanged before we decide to support more different methods to find a suggested learning rate in the future.


[pr_content_01]: https://github.com/davidtvs/pytorch-lr-finder/pull/98/files#diff-9f0f2c78a4013837c96649871bae6601cbd8ab855f37982f19e91a175be0ee79R541-R542