### PR TITLE
Fix ci-build status badge and link status badge to actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyTorch learning rate finder
 
-[![ci-build status](https://github.com/davidtvs/pytorch-lr-finder/actions/workflows/ci_build.yml/badge.svg?branch=master)](https://github.com/davidtvs/pytorch-lr-finder/actions?query=branch%3Amaster)
+[![ci-build status](https://github.com/davidtvs/pytorch-lr-finder/actions/workflows/ci_build.yml/badge.svg?branch=master)](https://github.com/davidtvs/pytorch-lr-finder/actions/workflows/ci_build.yml?query=branch%3Amaster)
 [![codecov](https://codecov.io/gh/davidtvs/pytorch-lr-finder/branch/master/graph/badge.svg)](https://codecov.io/gh/davidtvs/pytorch-lr-finder)
 [![](https://img.shields.io/pypi/v/torch-lr-finder)](https://pypi.org/project/torch-lr-finder/)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyTorch learning rate finder
 
-![](https://github.com/davidtvs/pytorch-lr-finder/actions/workflows/ci_build.yml/badge.svg?branch=master)
+[![ci-build status](https://github.com/davidtvs/pytorch-lr-finder/actions/workflows/ci_build.yml/badge.svg?branch=master)](https://github.com/davidtvs/pytorch-lr-finder/actions?query=branch%3Amaster)
 [![codecov](https://codecov.io/gh/davidtvs/pytorch-lr-finder/branch/master/graph/badge.svg)](https://codecov.io/gh/davidtvs/pytorch-lr-finder)
 [![](https://img.shields.io/pypi/v/torch-lr-finder)](https://pypi.org/project/torch-lr-finder/)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyTorch learning rate finder
 
-![](https://github.com/davidtvs/pytorch-lr-finder/workflows/ci-build/badge.svg?branch=master)
+![](https://github.com/davidtvs/pytorch-lr-finder/actions/workflows/ci_build.yml/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/davidtvs/pytorch-lr-finder/branch/master/graph/badge.svg)](https://codecov.io/gh/davidtvs/pytorch-lr-finder)
 [![](https://img.shields.io/pypi/v/torch-lr-finder)](https://pypi.org/project/torch-lr-finder/)
 


### PR DESCRIPTION
# Background

![Screenshot 2024-09-16 at 11 25 04](https://github.com/user-attachments/assets/c9cb5e28-35b2-4ed3-a3a5-d8055d9e8c93)

The ci-build status badge on README.md is showing no status, even though the action recently ran successfully.

The status badge was added 4 years ago, so I'm guessing GitHub made a breaking change since then, though I found no documentation to confirm this. I suspect the problem is some GitHub edge case related to the name of the yaml file being `ci_build.yml` but the name of the action being `ci-build`.

# Changes

1. Updated the badge URL to the current format publised on [Add a status badge > Using the branch parameter](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-branch-parameter).
2. Change badge to link to ci-build action runs on master branch. It previously linked to an SVG of the badge.

# Testing

## status badge

Before change:

![Screenshot 2024-09-16 at 11 30 09](https://github.com/user-attachments/assets/4333fb23-927c-4f3f-8813-ca1393a8e6bb)

After change:

![Screenshot 2024-09-16 at 11 31 09](https://github.com/user-attachments/assets/c590aa66-9358-45ec-beec-537c5b6dbfb6)

## clicking on badge

Before change, clicking on badge takes you to https://github.com/davidtvs/pytorch-lr-finder/workflows/ci-build/badge.svg?branch=master


After change, clicking on badge takes you to: https://github.com/davidtvs/pytorch-lr-finder/actions/workflows/ci_build.yml?query=branch%3Amaster


